### PR TITLE
Add 2026/2027 committee

### DIFF
--- a/src/assets/committee/current.csv
+++ b/src/assets/committee/current.csv
@@ -1,19 +1,18 @@
 Position,Name,ID,College,Course
-Chair,Tatiana Mouzykantskii,tmbm4,Trinity,Natural Sciences
-Secretary,Anubhav Nundy,an728,Sidney Sussex,Natural Sciences
-Treasurer,David Parodi,dp706,Girton,Natural Sciences
-Events Officer,Mara Rotaru,mar205,Lucy Cavendish,Engineering
-Neptune Editor,Ivan Bortnovskyi,ib538,Churchill,Mathematics
-Webmaster,Thomas Holland,th675,Jesus,Natural Sciences
-Membership,Thomas Holland,th675,Jesus,Natural Sciences
-Stash Officer,Precious Okafor,po302,Fitzwilliam,Natural Sciences
-Speaker Liaison ,Yunkai (Harry) Wu,yw702,Clare,Natural Sciences
-Publicity,Jianing Xing,jx312,Lucy Cavendish,Chemical Engineering
+Chair,Anubhav Nundy,an728,Sidney Sussex,Natural Sciences
+Secretary,Arran Greig,ag2522,Churchill,Natural Sciences
+Treasurer,Liu Hao,hl731,Christ's,Natural Sciences
+Speaker Liaison,Rosa Hadfield,rhm84,Jesus,Natural Sciences
+Speaker Liaison,Yunkai (Harry) Wu,yw702,Clare,Natural Sciences
+Neptune Editor,Lan Hall,ldh37,Lucy Cavendish,Mathematics
+Neptune Editor,Yuehang (Aria) She,ys681,King's,Mathematics
+Webmaster,Martin Kudrna,mk2337,Trinity,Computer Science
+Membership,Liu Hao,hl731,Christ's,Natural Sciences
+Stash Officer,Rosa Hadfield,rhm84,Jesus,Natural Sciences
+Stash Officer,Rory Moloney,rom24,Pembroke,Natural Sciences
+Sponsorship Officer,Rosa Hadfield,rhm84,Jesus,Natural Sciences
+Publicity,Lan Hall,ldh37,Lucy Cavendish,Mathematics
 Obs. Secretary,Ivan Bortnovskyi,ib538,Churchill,Mathematics
-Obs. Secretary,Maeen Tell,mt953,Sidney Sussex,Natural Sciences
-Obs. Secretary,Peter Jackson,pj375,Girton,Natural Sciences
-Obs. Secretary,William Mena,wm355,Trinity Hall,Natural Sciences
-Obs. Secretary,Yunkai/Harry Wu,yw702,Clare,Natural Sciences
-Obs. Secretary,Anubhav Nundy,an728,Sidney Sussex,Natural Sciences
-Obs. Secretary,Ihor Pylaiev,ip406,Christ's,Mathematics
-Obs. Secretary,Tatiana Mouzykantskii,tmbm4,Trinity,Natural Sciences
+Obs. Secretary,William Moorhouse,wm378,Peterhouse,Natural Sciences
+Obs. Secretary,Arjun Randhawa,apsr2,Churchill,Natural Sciences
+Obs. Secretary,All other committee members,,,

--- a/src/assets/committee/historic.csv
+++ b/src/assets/committee/historic.csv
@@ -1,4 +1,4 @@
-YearStart	YearEnd	Chair	Secretary	Treasurer	Other1	Other2	Other3	Other4	Other5	Other6	Other7
+YearStart	YearEnd	Chair	Secretary	Treasurer	Other1	Other2	Other3	Other4	Other5	Other6	Other7	Other8	Other9	Other10
 1942	1943	John L Lewis (Pembroke)	A. Blakey (Newnham)	P.V. Fitton (Sidney)	C. Billington (Caius)	P.A.R. Brown (King's)	P. Eastwood (Clare)	L.H. Farnsworth (Downing)	H.S. Rendle (St Catherine's)		
 1943	1944	John L Lewis (Pembroke)	A. Blakey (Newnham)	H.S. Rendle (St Catharine's)	C. Billington (Caius)	S. Harvey (Newnham)	L.H. Long (Dr.) (Emma)	J.G.D. Pratt (Trinity)	E.F. Rogers (Sidney)		
 1944	1945	J.G.D. Pratt (Trinity)	J.A. Bancroft-Wilson (Sidney)	E.L. Campbell (Pembroke)	J.S. Cushen (Girton)	T.N. Dewey (Pembroke)	K.G. Eckhoff (SIdney)	John L Lewis (Pembroke)	L.H. Long (Dr.) (Emma)		
@@ -82,3 +82,4 @@ YearStart	YearEnd	Chair	Secretary	Treasurer	Other1	Other2	Other3	Other4	Other5	O
 2022	2023	Lehan Li (Murray Edwards)	Jessica Lok (Fitzwilliam)	Shikang Ni (Wolfson)	Ralph Battle (Emma)	Joseph Thornton (Robinson)	Aniruddha Aramanekoppa (Fitzwilliam)	Haozhe Zhu (Downing)	Xavior Wang Xuchen (St Edmunds) (publicity)	Steve Shen (Emma) 	ChonTong Cheong (Trinity Hall) 
 2023	2024	Alex Blake-Martin (Fitzwilliam)	Jessica Lok (Fitzwilliam)	Sam Webber (Churchill)	Aniruddha Aramanekoppa (Fitzwilliam)	Mahdeia Hidary (Fitzwilliam) 	Guang Liang Yeo (St Edmund's)	Charlie Mack (Fitzwilliam) 	Daniel Choi (St John's) 	Daniel Nicolae (Trinity) 	(Resigned: ChonTong Cheong (Trinity Hall) )
 2024	2025	Mara-Andreea Rotaru (Lucy Cavendish)	Bryant Li (Lucy Cavendish)	Man Yu Kelly Kwok (Christ's)	Peter Jackson (Girton)	Maeen Tell (Sidney) 	Abigail Liew	Mahdeia Hidary			
+2025	2026	Tatiana Mouzykantskii (Trinity)	Anubhav Nundy (Sidney Sussex)	David Parodi (Girton)	Mara Rotaru (Lucy Cavendish)	Ivan Bortnovskyi (Churchill)	Thomas Holland (Jesus)	Precious Okafor (Fitzwilliam)	Yunkai (Harry) Wu (Clare)	Jianing Xing (Lucy Cavendish)	Maeen Tell (Sidney Sussex)	Peter Jackson (Girton)	William Mena (Trinity Hall)	Ihor Pylaiev (Christ's)

--- a/src/pages/about/committee.astro
+++ b/src/pages/about/committee.astro
@@ -71,7 +71,9 @@ const currentSeniorTreasurer = seniorCommittee.find(
                             <td>{member.Name}</td>
                             <td>{member.ID}</td>
                             <td>
-                                {member.College} - {member.Course}
+                                {[member.College, member.Course]
+                                    .filter(Boolean)
+                                    .join(" - ")}
                             </td>
                         </tr>
                     ))
@@ -85,17 +87,21 @@ const currentSeniorTreasurer = seniorCommittee.find(
     <p>
         Our current President is {
             currentPresident.url ? (
-                <a href={currentPresident.url} target="_blank">
-                    {currentPresident.Name}
-                </a>
+                <a
+                    href={currentPresident.url}
+                    target="_blank"
+                    set:text={currentSeniorTreasurer.Name}
+                />
             ) : (
                 currentPresident.Name
             )
         } and our current Senior Treasurer is {
             currentSeniorTreasurer.url ? (
-                <a href={currentSeniorTreasurer.url} target="_blank">
-                    {currentSeniorTreasurer.Name}
-                </a>
+                <a
+                    href={currentSeniorTreasurer.url}
+                    target="_blank"
+                    set:text={currentSeniorTreasurer.Name}
+                />
             ) : (
                 currentSeniorTreasurer.Name
             )

--- a/src/pages/about/committee.astro
+++ b/src/pages/about/committee.astro
@@ -1,107 +1,201 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import { readFileSync } from 'fs';
-import Papa from 'papaparse';
+import Layout from "../../layouts/Layout.astro";
+import { readFileSync } from "fs";
+import Papa from "papaparse";
 
 const { parse } = Papa;
 
-const [currentCommittee, seniorCommittee, historicCommittee] = ['current.csv', 'senior.csv', 'historic.csv'].map(file => parse(readFileSync(`src/assets/committee/${file}`, 'utf8'), { header: true }).data);
+const [currentCommittee, seniorCommittee, historicCommittee] = [
+    "current.csv",
+    "senior.csv",
+    "historic.csv",
+].map(
+    (file) =>
+        parse(readFileSync(`src/assets/committee/${file}`, "utf8"), {
+            header: true,
+        }).data,
+);
 
-const currentPresident = seniorCommittee.find(member => member.Role === 'President' && member.YearEnd === 'Present');
-const currentSeniorTreasurer = seniorCommittee.find(member => member.Role === 'Senior Treasurer' && member.YearEnd === 'Present');
+const currentPresident = seniorCommittee.find(
+    (member) => member.Role === "President" && member.YearEnd === "Present",
+);
+const currentSeniorTreasurer = seniorCommittee.find(
+    (member) =>
+        member.Role === "Senior Treasurer" && member.YearEnd === "Present",
+);
 ---
 
 <Layout>
+    <h1>Committee</h1>
 
-<h1>Committee</h1>
+    <p>
+        The committee is composed of university students and is responsible for
+        the day to day running of the society. Please contact them if you have
+        any questions. At the end of Lent term there is an opportunity to stand
+        for next year’s committee. If you are interested please contact a member
+        of the committee.
+    </p>
 
-<p>The committee is composed of university students and is responsible for the day to day running of the society. Please contact them if you have any questions. At the end of Lent term there is an opportunity to stand for next year’s committee. If you are interested please contact a member of the committee.</p>
+    <p>
+        To contact individual committee members via email, add “@cam.ac.uk”
+        after the combination of letters and numbers given. If you encounter
+        problems contacting the committee members, please contact the webmaster
+        directly.
+    </p>
 
-<p>To contact individual committee members via email, add “@cam.ac.uk” after the combination of letters and numbers given. If you encounter problems contacting the committee members, please contact the webmaster directly.</p>
+    <p>
+        <strong
+            >The best way to contact the Obs Secretaries is via their shared
+            email: <a href="mailto:cuasobserv@gmail.com">cuasobserv@gmail.com</a
+            ></strong
+        >
+    </p>
 
-<p><strong>The best way to contact the Obs Secretaries is via their shared email: <a href="mailto:cuasobserv@gmail.com">cuasobserv@gmail.com</a></strong></p>
+    <h2>Current Committee</h2>
 
-<h2>Current Committee</h2>
-
-<div class="container">
-    <table>
-        <thead>
-            <tr>
-                <th>Position</th>
-                <th>Name</th>
-                <th>@cam.ac.uk</th>
-                <th>College and Course</th>
-            </tr>
-        </thead>
-        <tbody>
-            {currentCommittee.map(member => (
+    <div class="container">
+        <table>
+            <thead>
                 <tr>
-                    <td>{member.Position}</td>
-                    <td>{member.Name}</td>
-                    <td>{member.ID}</td>
-                    <td>{member.College} - {member.Course}</td>
+                    <th>Position</th>
+                    <th>Name</th>
+                    <th>@cam.ac.uk</th>
+                    <th>College and Course</th>
                 </tr>
-            ))}
-        </tbody>
-    </table>
-</div>
-
-<h2>Senior Committee</h2>
-
-<p>Our current President is {currentPresident.url ? <a href={currentPresident.url} target="_blank">{currentPresident.Name}</a> : currentPresident.Name} and our current Senior Treasurer is {currentSeniorTreasurer.url ? <a href={currentSeniorTreasurer.url} target="_blank">{currentSeniorTreasurer.Name}</a> : currentSeniorTreasurer.Name}.</p>
-
-<div class="container flex flex-col md:flex-row">
-    <div class="flex-1 p-4">
-        <h3 class="text-xl font-bold">Previous Presidents</h3>
-        <ul class="list-disc list-inside">
-            {seniorCommittee.filter(member => member.Role === 'President' && member.YearEnd !== 'Present').map(president => (
-                <li>{president.Name} ({president.YearStart}-{president.YearEnd})</li>
-            ))}
-        </ul>
+            </thead>
+            <tbody>
+                {
+                    currentCommittee.map((member) => (
+                        <tr>
+                            <td>{member.Position}</td>
+                            <td>{member.Name}</td>
+                            <td>{member.ID}</td>
+                            <td>
+                                {member.College} - {member.Course}
+                            </td>
+                        </tr>
+                    ))
+                }
+            </tbody>
+        </table>
     </div>
-    <div class="flex-1 p-4">
-        <h3 class="text-xl font-bold">Previous Senior Treasurers</h3>
-        <ul class="list-disc list-inside">
-            {seniorCommittee.filter(member => member.Role === 'Senior Treasurer' && member.YearEnd !== 'Present').map(treasurer => (
-                <li>{treasurer.Name} ({treasurer.YearStart}-{treasurer.YearEnd})</li>
-            ))}
-        </ul>
+
+    <h2>Senior Committee</h2>
+
+    <p>
+        Our current President is {
+            currentPresident.url ? (
+                <a href={currentPresident.url} target="_blank">
+                    {currentPresident.Name}
+                </a>
+            ) : (
+                currentPresident.Name
+            )
+        } and our current Senior Treasurer is {
+            currentSeniorTreasurer.url ? (
+                <a href={currentSeniorTreasurer.url} target="_blank">
+                    {currentSeniorTreasurer.Name}
+                </a>
+            ) : (
+                currentSeniorTreasurer.Name
+            )
+        }.
+    </p>
+
+    <div class="container flex flex-col md:flex-row">
+        <div class="flex-1 p-4">
+            <h3 class="text-xl font-bold">Previous Presidents</h3>
+            <ul class="list-disc list-inside">
+                {
+                    seniorCommittee
+                        .filter(
+                            (member) =>
+                                member.Role === "President" &&
+                                member.YearEnd !== "Present",
+                        )
+                        .map((president) => (
+                            <li>
+                                {president.Name} ({president.YearStart}-
+                                {president.YearEnd})
+                            </li>
+                        ))
+                }
+            </ul>
+        </div>
+        <div class="flex-1 p-4">
+            <h3 class="text-xl font-bold">Previous Senior Treasurers</h3>
+            <ul class="list-disc list-inside">
+                {
+                    seniorCommittee
+                        .filter(
+                            (member) =>
+                                member.Role === "Senior Treasurer" &&
+                                member.YearEnd !== "Present",
+                        )
+                        .map((treasurer) => (
+                            <li>
+                                {treasurer.Name} ({treasurer.YearStart}-
+                                {treasurer.YearEnd})
+                            </li>
+                        ))
+                }
+            </ul>
+        </div>
     </div>
-</div>
 
-<h2>Past committees</h2>
+    <h2>Past committees</h2>
 
-<div class="container">
-    <table>
-        <thead>
-            <tr>
-                <th>Year</th>
-                <th>Chair</th>
-                <th>Secretary</th>
-                <th>Treasurer</th>
-                <th>Other Members</th>
-            </tr>
-        </thead>
-        <tbody>
-            {historicCommittee.map(year => (
+    <div class="container">
+        <table>
+            <thead>
                 <tr>
-                    <td>{year.YearStart}-{year.YearEnd}</td>
-                    <td>{year.Chair}</td>
-                    <td>{year.Secretary}</td>
-                    <td>{year.Treasurer}</td>
-                    <td>
-                        {year.Other1}<br />
-                        {year.Other2}<br />
-                        {year.Other3}<br />
-                        {year.Other4}<br />
-                        {year.Other5}<br />
-                        {year.Other6}<br />
-                        {year.Other7}
-                    </td>
+                    <th>Year</th>
+                    <th>Chair</th>
+                    <th>Secretary</th>
+                    <th>Treasurer</th>
+                    <th>Other Members</th>
                 </tr>
-            ))}
-        </tbody>
-    </table>
-</div>
-
+            </thead>
+            <tbody>
+                {
+                    historicCommittee.map((year) => (
+                        <tr>
+                            <td>
+                                {year.YearStart}-{year.YearEnd}
+                            </td>
+                            <td>{year.Chair}</td>
+                            <td>{year.Secretary}</td>
+                            <td>{year.Treasurer}</td>
+                            <td>
+                                {[
+                                    year.Other1,
+                                    year.Other2,
+                                    year.Other3,
+                                    year.Other4,
+                                    year.Other5,
+                                    year.Other6,
+                                    year.Other7,
+                                    year.Other8,
+                                    year.Other9,
+                                    year.Other10,
+                                ]
+                                    .filter(
+                                        (role) =>
+                                            role !== null &&
+                                            role !== undefined &&
+                                            role.trim() !== "",
+                                    )
+                                    .map((role) => (
+                                        <>
+                                            {role}
+                                            <br />
+                                        </>
+                                    ))}
+                            </td>
+                        </tr>
+                    ))
+                }
+            </tbody>
+        </table>
+    </div>
 </Layout>


### PR DESCRIPTION
Moves the 2025/2026 committee to the historic page
Adds the 2026/2027 committee
Improves the historic committees table rendering by not adding empty lines to those years with fewer members
Improves the current committee table rendering by handling the cases when college/course is missing (currently used to add a note that all committee members are also observation secretaries)